### PR TITLE
Add neural network utilities and bank MLP

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.linear_model import LogisticRegression
 from baseline_dt import run_all as run_dt_baseline
 from sklearn.tree import DecisionTreeClassifier
+from sklearn.neural_network import MLPClassifier
 from sklearn.metrics import classification_report, accuracy_score
 import time
 
@@ -103,6 +104,34 @@ def train_bank(X_train, X_test, y_train, y_test):
         }
     )
 
+
+def train_bank_mlp(X_train, X_test, y_train, y_test):
+    """Train scikit-learn MLPClassifier on the bank dataset."""
+    start = time.time()
+    hyper = {"hidden_layer_sizes": (100,), "max_iter": 300, "random_state": 42}
+    clf = MLPClassifier(**hyper)
+    clf.fit(X_train, y_train)
+    preds = clf.predict(X_test)
+    elapsed = time.time() - start
+
+    print("Bank Marketing dataset results (MLP):")
+    print(classification_report(y_test, preds, zero_division=0))
+    acc = accuracy_score(y_test, preds)
+    print("Accuracy:", acc)
+
+    report = classification_report(y_test, preds, output_dict=True, zero_division=0)
+    results_dt.append(
+        {
+            "dataset": "Bank Marketing",
+            "method": "MLPClassifier",
+            "hyperparameters": hyper,
+            "accuracy": acc,
+            "precision": report["weighted avg"]["precision"],
+            "recall": report["weighted avg"]["recall"],
+            "f1": report["weighted avg"]["f1-score"],
+            "duration": elapsed,
+        }
+    )
 
 # ---------------- Books Reviews Dataset -----------------
 
@@ -258,6 +287,7 @@ def run_all():
     if csv_file is not None:
         X_train, X_test, y_train, y_test = preprocess_bank(csv_file)
         train_bank(X_train, X_test, y_train, y_test)
+        train_bank_mlp(X_train, X_test, y_train, y_test)
 
     # Books Reviews
     books_df = load_books_dataset()

--- a/neural_models.py
+++ b/neural_models.py
@@ -1,0 +1,266 @@
+# Neural network architectures extracted from archive/trabalhoia3.py
+# and refactored into reusable functions.
+
+from __future__ import annotations
+
+import time
+from typing import Tuple, Iterable
+
+import numpy as np
+from sklearn.metrics import accuracy_score, classification_report
+from sklearn.neural_network import MLPClassifier
+from tensorflow import keras
+from tensorflow.keras import layers
+import tensorflow as tf
+
+
+# ---------------------- Tabular Data ----------------------
+
+def train_mlp_sklearn(X_train: np.ndarray, X_test: np.ndarray,
+                       y_train: Iterable, y_test: Iterable,
+                       hidden_layer_sizes=(100,), max_iter=300) -> dict:
+    """Train a scikit-learn MLPClassifier and return metrics."""
+    start = time.time()
+    clf = MLPClassifier(hidden_layer_sizes=hidden_layer_sizes,
+                        max_iter=max_iter,
+                        random_state=42)
+    clf.fit(X_train, y_train)
+    preds = clf.predict(X_test)
+
+    report = classification_report(y_test, preds, output_dict=True, zero_division=0)
+    acc = accuracy_score(y_test, preds)
+
+    return {
+        "method": "MLPClassifier",
+        "accuracy": acc,
+        "precision": report["weighted avg"]["precision"],
+        "recall": report["weighted avg"]["recall"],
+        "f1": report["weighted avg"]["f1-score"],
+        "duration": time.time() - start,
+    }
+
+
+def train_mlp_keras(X_train: np.ndarray, X_test: np.ndarray,
+                    y_train: Iterable, y_test: Iterable,
+                    epochs: int = 50) -> dict:
+    """Train a simple Keras MLP for binary classification."""
+    start = time.time()
+    model = keras.Sequential(
+        [
+            layers.Dense(128, activation="relu", input_shape=(X_train.shape[1],)),
+            layers.Dropout(0.3),
+            layers.Dense(64, activation="relu"),
+            layers.Dropout(0.3),
+            layers.Dense(32, activation="relu"),
+            layers.Dense(1, activation="sigmoid"),
+        ]
+    )
+
+    model.compile(optimizer="adam",
+                  loss="binary_crossentropy",
+                  metrics=["accuracy"])
+
+    model.fit(X_train, y_train, epochs=epochs, validation_split=0.2,
+              callbacks=[keras.callbacks.EarlyStopping(monitor='val_loss',
+                                                        patience=5,
+                                                        restore_best_weights=True)],
+              verbose=0)
+
+    loss, acc = model.evaluate(X_test, y_test, verbose=0)
+    return {
+        "method": "Keras MLP",
+        "accuracy": acc,
+        "loss": loss,
+        "duration": time.time() - start,
+    }
+
+
+# ---------------------- Image Data ----------------------
+
+IMG_SIZE = (180, 180)
+BATCH_SIZE = 32
+
+def _prep_image_ds(ds):
+    def resize_norm(img, label):
+        img = tf.image.resize(img, IMG_SIZE)
+        img = img / 255.0
+        return img, label
+    return ds.map(resize_norm).batch(BATCH_SIZE).prefetch(tf.data.AUTOTUNE)
+
+
+def train_cnn_simple(ds_train, ds_val, ds_test, num_classes: int,
+                     epochs: int = 10) -> dict:
+    """Train a small CNN for image classification."""
+    start = time.time()
+    model = keras.Sequential(
+        [
+            layers.Conv2D(32, 3, activation="relu", input_shape=(*IMG_SIZE, 3)),
+            layers.MaxPooling2D(),
+            layers.Conv2D(64, 3, activation="relu"),
+            layers.MaxPooling2D(),
+            layers.Flatten(),
+            layers.Dense(128, activation="relu"),
+            layers.Dense(num_classes, activation="softmax"),
+        ]
+    )
+
+    model.compile(optimizer="adam",
+                  loss="sparse_categorical_crossentropy",
+                  metrics=["accuracy"])
+
+    model.fit(_prep_image_ds(ds_train), validation_data=_prep_image_ds(ds_val),
+              epochs=epochs, verbose=0)
+
+    loss, acc = model.evaluate(_prep_image_ds(ds_test), verbose=0)
+    return {
+        "method": "Simple CNN",
+        "accuracy": acc,
+        "loss": loss,
+        "duration": time.time() - start,
+    }
+
+
+def train_cnn_deep(ds_train, ds_val, ds_test, num_classes: int,
+                    epochs: int = 20) -> dict:
+    """Train a deeper CNN with additional layers."""
+    start = time.time()
+    model = keras.Sequential(
+        [
+            layers.Conv2D(32, 3, activation="relu", input_shape=(*IMG_SIZE, 3)),
+            layers.MaxPooling2D(),
+            layers.Conv2D(64, 3, activation="relu"),
+            layers.MaxPooling2D(),
+            layers.Conv2D(128, 3, activation="relu"),
+            layers.MaxPooling2D(),
+            layers.Flatten(),
+            layers.Dense(256, activation="relu"),
+            layers.Dropout(0.4),
+            layers.Dense(num_classes, activation="softmax"),
+        ]
+    )
+
+    model.compile(optimizer="adam",
+                  loss="sparse_categorical_crossentropy",
+                  metrics=["accuracy"])
+
+    model.fit(
+        _prep_image_ds(ds_train),
+        validation_data=_prep_image_ds(ds_val),
+        epochs=epochs,
+        callbacks=[keras.callbacks.EarlyStopping(monitor='val_loss', patience=5,
+                                                 restore_best_weights=True)],
+        verbose=0,
+    )
+
+    loss, acc = model.evaluate(_prep_image_ds(ds_test), verbose=0)
+    return {
+        "method": "Deep CNN",
+        "accuracy": acc,
+        "loss": loss,
+        "duration": time.time() - start,
+    }
+
+
+# ---------------------- Text Data ----------------------
+
+def train_cnn_text(train_seq: np.ndarray, test_seq: np.ndarray,
+                   y_train: Iterable, y_test: Iterable,
+                   vocab_size: int, embedding_dim: int = 16,
+                   epochs: int = 10) -> dict:
+    """CNN model for text classification."""
+    start = time.time()
+    max_length = train_seq.shape[1]
+    model = keras.Sequential(
+        [
+            layers.Embedding(vocab_size, embedding_dim, input_length=max_length),
+            layers.Conv1D(128, 5, activation='relu'),
+            layers.GlobalMaxPooling1D(),
+            layers.Dense(64, activation='relu'),
+            layers.Dense(1, activation='sigmoid'),
+        ]
+    )
+
+    model.compile(optimizer='adam',
+                  loss='binary_crossentropy',
+                  metrics=['accuracy'])
+
+    model.fit(train_seq, y_train, epochs=epochs, validation_split=0.2, verbose=0)
+
+    loss, acc = model.evaluate(test_seq, y_test, verbose=0)
+    return {
+        "method": "CNN Text",
+        "accuracy": acc,
+        "loss": loss,
+        "duration": time.time() - start,
+    }
+
+
+def train_cnn_lstm_text(train_seq: np.ndarray, test_seq: np.ndarray,
+                         y_train: Iterable, y_test: Iterable,
+                         vocab_size: int, embedding_dim: int = 32,
+                         epochs: int = 10) -> dict:
+    """CNN + LSTM model for text classification."""
+    start = time.time()
+    max_length = train_seq.shape[1]
+    model = keras.Sequential(
+        [
+            layers.Embedding(vocab_size, embedding_dim, input_length=max_length),
+            layers.Conv1D(128, 5, activation='relu'),
+            layers.MaxPooling1D(),
+            layers.LSTM(64),
+            layers.Dense(64, activation='relu'),
+            layers.Dense(1, activation='sigmoid'),
+        ]
+    )
+
+    model.compile(optimizer='adam',
+                  loss='binary_crossentropy',
+                  metrics=['accuracy'])
+
+    model.fit(train_seq, y_train, epochs=epochs, validation_split=0.2,
+              callbacks=[keras.callbacks.EarlyStopping(monitor='val_loss', patience=5,
+                                                       restore_best_weights=True)],
+              verbose=0)
+
+    loss, acc = model.evaluate(test_seq, y_test, verbose=0)
+    return {
+        "method": "CNN+LSTM Text",
+        "accuracy": acc,
+        "loss": loss,
+        "duration": time.time() - start,
+    }
+
+
+def train_gru_text(train_seq: np.ndarray, test_seq: np.ndarray,
+                   y_train: Iterable, y_test: Iterable,
+                   vocab_size: int, embedding_dim: int = 32,
+                   epochs: int = 10) -> dict:
+    """GRU based model for text classification."""
+    start = time.time()
+    max_length = train_seq.shape[1]
+    model = keras.Sequential(
+        [
+            layers.Embedding(vocab_size, embedding_dim, input_length=max_length),
+            layers.GRU(64),
+            layers.Dense(64, activation='relu'),
+            layers.Dense(1, activation='sigmoid'),
+        ]
+    )
+
+    model.compile(optimizer='adam',
+                  loss='binary_crossentropy',
+                  metrics=['accuracy'])
+
+    model.fit(train_seq, y_train, epochs=epochs, validation_split=0.2,
+              callbacks=[keras.callbacks.EarlyStopping(monitor='val_loss', patience=5,
+                                                       restore_best_weights=True)],
+              verbose=0)
+
+    loss, acc = model.evaluate(test_seq, y_test, verbose=0)
+    return {
+        "method": "GRU Text",
+        "accuracy": acc,
+        "loss": loss,
+        "duration": time.time() - start,
+    }
+


### PR DESCRIPTION
## Summary
- create `neural_models.py` with reusable functions for MLP and CNN models
- support deeper CNNs and text CNNs as extra architectures
- add MLPClassifier training to the bank dataset workflow

## Testing
- `pip install pandas -q`
- `pip install scikit-learn -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686433fcbdc0832eba47265c9a8c7fa7