### PR TITLE
Add Portuguese comments and docstrings

### DIFF
--- a/avaliacao.py
+++ b/avaliacao.py
@@ -1,3 +1,4 @@
+"""Funções para avaliar e agregar resultados de modelos."""
 from __future__ import annotations
 
 from typing import List, Dict, Mapping
@@ -28,6 +29,7 @@ def avaliar_dataset(df: pd.DataFrame, target: str) -> List[Dict[str, float]]:
         List with one metrics dictionary per model. Each dictionary contains the
         keys ``method``, ``accuracy``, ``precision``, ``recall`` and ``f1``.
     """
+    # separa dados e treina modelos simples
     X = df.drop(columns=[target])
     y = df[target]
 
@@ -75,6 +77,7 @@ def agregar_resultados(csv_path: str) -> Mapping[str, pd.DataFrame]:
         A dictionary mapping each dataset name to a table with the aggregated
         metrics for every method tested.
     """
+    # agrupa métricas por dataset e método
     df = pd.read_csv(csv_path)
     metrics = ["accuracy", "precision", "recall", "f1", "duration"]
     grouped = df.groupby(["dataset", "method"])[metrics].mean().reset_index()
@@ -97,6 +100,7 @@ def gerar_tabelas(csv_path: str, out_dir: str = ".", prefix: str = "table") -> N
     prefix : str, optional
         Prefix used for the output filenames.
     """
+    # gera arquivos com tabelas sumarizadas
     tables = agregar_resultados(csv_path)
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)

--- a/baseline_arvore_decisao.py
+++ b/baseline_arvore_decisao.py
@@ -1,5 +1,4 @@
-# Baseline Decision Tree classifiers for Bank, Flowers, and Books datasets
-# Implements simple preprocessing and evaluation for each dataset
+"""Baseline de Árvores de Decisão para os conjuntos Bank, Books e Flowers."""
 
 from __future__ import annotations
 
@@ -45,6 +44,7 @@ def baixar_base_banco() -> Path:
 
 
 def preprocessar_banco(csv_file: Path) -> Tuple[pd.DataFrame, pd.Series]:
+    # carrega o CSV e normaliza colunas
     df = pd.read_csv(csv_file, sep=";")
     binary_map = {"yes": 1, "no": 0}
     for col in ["default", "housing", "loan", "y"]:
@@ -67,6 +67,7 @@ BOOKS_PATH = Path("books_reviews.csv")
 
 
 def preprocessar_livros() -> Tuple[pd.DataFrame, pd.Series]:
+    # prepara as resenhas de livros
     df = pd.read_csv(BOOKS_PATH)
     df = df.dropna(subset=["review_text", "label"]).copy()
     y = df["label"]
@@ -80,6 +81,7 @@ def preprocessar_livros() -> Tuple[pd.DataFrame, pd.Series]:
 
 
 def preprocessar_flores() -> Tuple[pd.DataFrame, pd.Series]:
+    # carrega o dataset de flores e extrai histogramas
     if tfds is None:
         raise RuntimeError("TensorFlow Datasets not available")
 
@@ -121,6 +123,7 @@ PARAMS_LIST = [
 
 
 def avaliar_dataset(X, y, dataset_name: str) -> List[Dict[str, object]]:
+    # separa dados, treina árvore e avalia
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=42
     )
@@ -153,6 +156,7 @@ results_dt: List[Dict[str, object]] = []
 
 
 def executar_tudo() -> pd.DataFrame:
+    # executa o pipeline completo
     global results_dt
     results_dt = []
 

--- a/modelos_neurais.py
+++ b/modelos_neurais.py
@@ -1,5 +1,4 @@
-# Neural network architectures extracted from archive/trabalhoia3.py
-# and refactored into reusable functions.
+"""Funções de redes neurais reutilizáveis para dados tabulares, texto e imagem."""
 
 from __future__ import annotations
 
@@ -19,6 +18,7 @@ import tensorflow as tf
 def treinar_mlp_sklearn(X_train: np.ndarray, X_test: np.ndarray,
                         y_train: Iterable, y_test: Iterable,
                         hidden_layer_sizes=(100,), max_iter=300) -> dict:
+    # treino de MLP usando scikit-learn
     """Train a scikit-learn MLPClassifier and return metrics."""
     start = time.time()
     clf = MLPClassifier(hidden_layer_sizes=hidden_layer_sizes,
@@ -44,6 +44,7 @@ def treinar_mlp_keras(X_train: np.ndarray, X_test: np.ndarray,
                       y_train: Iterable, y_test: Iterable,
                       epochs: int = 50) -> dict:
     """Train a simple Keras MLP for binary classification."""
+    # rede simples em Keras
     start = time.time()
     model = keras.Sequential(
         [
@@ -88,6 +89,7 @@ IMG_SIZE = (180, 180)
 BATCH_SIZE = 32
 
 def _preparar_ds_imagem(ds):
+    # redimensiona e normaliza imagens
     def resize_norm(img, label):
         img = tf.image.resize(img, IMG_SIZE)
         img = img / 255.0
@@ -98,6 +100,7 @@ def _preparar_ds_imagem(ds):
 def treinar_cnn_simples(ds_train, ds_val, ds_test, num_classes: int,
                         epochs: int = 10) -> dict:
     """Train a small CNN for image classification."""
+    # CNN simples para imagens
     start = time.time()
     model = keras.Sequential(
         [
@@ -141,6 +144,7 @@ def treinar_cnn_simples(ds_train, ds_val, ds_test, num_classes: int,
 def treinar_cnn_profundo(ds_train, ds_val, ds_test, num_classes: int,
                          epochs: int = 20) -> dict:
     """Train a deeper CNN with additional layers."""
+    # versão mais profunda da CNN
     start = time.time()
     model = keras.Sequential(
         [
@@ -197,6 +201,7 @@ def treinar_cnn_texto(train_seq: np.ndarray, test_seq: np.ndarray,
                       vocab_size: int, embedding_dim: int = 16,
                       epochs: int = 10) -> dict:
     """CNN model for text classification."""
+    # CNN para classificação de texto
     start = time.time()
     max_length = train_seq.shape[1]
     model = keras.Sequential(
@@ -236,6 +241,7 @@ def treinar_cnn_lstm_texto(train_seq: np.ndarray, test_seq: np.ndarray,
                             vocab_size: int, embedding_dim: int = 32,
                             epochs: int = 10) -> dict:
     """CNN + LSTM model for text classification."""
+    # combinação de CNN e LSTM para texto
     start = time.time()
     max_length = train_seq.shape[1]
     model = keras.Sequential(
@@ -279,6 +285,7 @@ def treinar_gru_texto(train_seq: np.ndarray, test_seq: np.ndarray,
                       vocab_size: int, embedding_dim: int = 32,
                       epochs: int = 10) -> dict:
     """GRU based model for text classification."""
+    # modelo baseado em GRU
     start = time.time()
     max_length = train_seq.shape[1]
     model = keras.Sequential(

--- a/principal.py
+++ b/principal.py
@@ -1,3 +1,4 @@
+"""Script principal que executa treinamentos nos três conjuntos de dados."""
 import zipfile
 import subprocess
 from pathlib import Path
@@ -57,6 +58,7 @@ def baixar_base_banco():
 
 
 def preprocessar_banco(csv_file: Path):
+    # prepara o dataset bancário
     df = pd.read_csv(csv_file, sep=";")
     df = df.copy()
 
@@ -84,6 +86,7 @@ def preprocessar_banco(csv_file: Path):
 
 
 def treinar_banco(X_train, X_test, y_train, y_test):
+    # árvore de decisão no dataset bancário
     start = time.time()
     hyper = {"random_state": 42}
     clf = DecisionTreeClassifier(**hyper)
@@ -113,6 +116,7 @@ def treinar_banco(X_train, X_test, y_train, y_test):
 
 def treinar_banco_mlp(X_train, X_test, y_train, y_test):
     """Train scikit-learn MLPClassifier on the bank dataset."""
+    # MLP do scikit-learn
     start = time.time()
     hyper = {"hidden_layer_sizes": (100,), "max_iter": 300, "random_state": 42}
     clf = MLPClassifier(**hyper)
@@ -141,6 +145,7 @@ def treinar_banco_mlp(X_train, X_test, y_train, y_test):
 
 
 def treinar_banco_keras_mlp(X_train, X_test, y_train, y_test):
+    # MLP implementado em Keras
     metrics = treinar_mlp_keras(X_train, X_test, y_train, y_test, epochs=50)
     results_dt.append(
         {
@@ -165,10 +170,12 @@ def carregar_base_livros(path: str = "books_reviews.csv"):
     root. The default path was adjusted so ``executar_tudo()`` works out of the
     box without additional configuration.
     """
+    # carrega o CSV de resenhas
     return pd.read_csv(path)
 
 
 def preprocessar_livros(df: pd.DataFrame):
+    # gera representações TF-IDF
     df = df.dropna(subset=["review_text", "label"]).copy()
     X = df["review_text"].astype(str)
     y = df["label"]
@@ -187,6 +194,7 @@ def preprocessar_livros(df: pd.DataFrame):
 def preprocessar_livros_seq(df: pd.DataFrame, num_words: int = 10000,
                             max_len: int = 200):
     """Tokenize text reviews for neural models."""
+    # produz sequências de tokens
     df = df.dropna(subset=["review_text", "label"]).copy()
     X = df["review_text"].astype(str)
     y = df["label"]
@@ -213,6 +221,7 @@ def preprocessar_livros_seq(df: pd.DataFrame, num_words: int = 10000,
 
 
 def treinar_livros(X_train, X_test, y_train, y_test):
+    # regressão logística nas resenhas
     start = time.time()
     hyper = {"max_iter": 1000}
     clf = LogisticRegression(**hyper)
@@ -241,6 +250,7 @@ def treinar_livros(X_train, X_test, y_train, y_test):
 
 
 def treinar_livros_cnn(train_seq, test_seq, y_train, y_test, vocab_size):
+    # CNN simples para texto
     metrics = treinar_cnn_texto(train_seq, test_seq, y_train, y_test, vocab_size)
     results_dt.append(
         {
@@ -257,6 +267,7 @@ def treinar_livros_cnn(train_seq, test_seq, y_train, y_test, vocab_size):
 
 
 def treinar_livros_cnn_lstm(train_seq, test_seq, y_train, y_test, vocab_size):
+    # CNN combinada com LSTM
     metrics = treinar_cnn_lstm_texto(train_seq, test_seq, y_train, y_test, vocab_size)
     results_dt.append(
         {
@@ -275,6 +286,7 @@ def treinar_livros_cnn_lstm(train_seq, test_seq, y_train, y_test, vocab_size):
 # ---------------- TF Flowers Dataset -----------------
 
 def carregar_tf_flores():
+    # carrega dataset de flores do TensorFlow
     if tfds is None:
         print("TensorFlow datasets is not available.")
         return None
@@ -291,6 +303,7 @@ def carregar_tf_flores():
 
 
 def preprocessar_tf_flores(ds_train, ds_val, ds_test):
+    # normaliza e redimensiona imagens
     IMG_SIZE = (180, 180)
     BATCH_SIZE = 32
 
@@ -309,6 +322,7 @@ def preprocessar_tf_flores(ds_train, ds_val, ds_test):
 
 
 def treinar_flores(ds_train, ds_val, ds_test, num_classes):
+    # CNN simples para o dataset de flores
     start = time.time()
     hyper = {"epochs": 3}
     model = keras.Sequential(
@@ -360,6 +374,7 @@ def treinar_flores(ds_train, ds_val, ds_test, num_classes):
 
 
 def treinar_flores_profundo(ds_train, ds_val, ds_test, num_classes):
+    # versão mais profunda da CNN
     metrics = treinar_cnn_profundo(ds_train, ds_val, ds_test, num_classes)
     results_dt.append(
         {
@@ -378,6 +393,7 @@ def treinar_flores_profundo(ds_train, ds_val, ds_test, num_classes):
 # ---------------- Main Script -----------------
 
 def executar_tudo():
+    # orquestra todos os experimentos
     global results_dt
     results_dt = []
     # Bank Marketing

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Pacote de testes automatizados."""

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,3 +1,4 @@
+"""Testes para a função de agregação de resultados."""
 import pandas as pd
 import pytest
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,3 +1,4 @@
+"""Testes para a função de avaliação de modelos."""
 import pandas as pd
 from sklearn.datasets import make_classification
 


### PR DESCRIPTION
## Summary
- document main scripts and tests with short docstrings
- add succinct comments in Portuguese describing data processing and model blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659a0bf514832ea27d07a0e6d5d4df